### PR TITLE
Added an explanation why `REMOVE WIDGET` syntax fails when using DBR …

### DIFF
--- a/02 - Notebooks/01 - Notebooks and chunks.ipynb
+++ b/02 - Notebooks/01 - Notebooks and chunks.ipynb
@@ -4,7 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "c5f1b526-3e33-4c8a-a633-22b0df0b7781",
      "showTitle": false,
@@ -31,7 +34,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "179a203e-b9f9-4754-9fa7-bb73637a5546",
      "showTitle": false,
@@ -50,7 +56,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "df77757b-9d4b-4717-b72d-8b72bea21ad3",
      "showTitle": false,
@@ -67,7 +76,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "d02636fe-7021-43f1-9419-c8207cb66ffc",
      "showTitle": false,
@@ -90,7 +102,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "bd8a79d1-dc12-4719-b3af-78f5b0571402",
      "showTitle": false,
@@ -121,7 +136,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "f5a7636c-88c2-4eae-b8f4-fef7a7cff567",
      "showTitle": false,
@@ -150,7 +168,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "e1befdd2-cd20-4b29-ac15-f79f6f9a914a",
      "showTitle": false,
@@ -171,7 +192,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "76c591a2-0875-4cb6-af13-555110e56b06",
      "showTitle": false,
@@ -192,7 +216,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a0fbba02-2362-434a-a295-843c499f0894",
      "showTitle": false,
@@ -219,7 +246,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "0c0759c4-614b-4424-8cd3-96554a63c026",
      "showTitle": false,
@@ -256,7 +286,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "6d865afc-a347-4c7a-88c6-00d5a1ca4ed5",
      "showTitle": false,
@@ -278,7 +311,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "6381ef77-56b7-4876-bf77-6e6f71b437ee",
      "showTitle": false,
@@ -297,7 +333,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "215b9bcf-6304-4e2e-9b86-3071e6789dab",
      "showTitle": false,
@@ -328,7 +367,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "72d18fe4-7bca-45e0-a75a-832b823ec58d",
      "showTitle": false,
@@ -370,7 +412,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "0e8790a7-a44b-4e64-92bb-280eb8adaab9",
      "showTitle": false,
@@ -410,7 +455,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "2abeec0f-8fb0-49a3-a51d-5fac708e0560",
      "showTitle": false,
@@ -450,7 +498,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "322afc87-9692-4ee6-85a1-e0bcb13683da",
      "showTitle": false,
@@ -490,7 +541,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "231a7b91-7442-4ad0-aca8-ecf79f528ac4",
      "showTitle": false,
@@ -510,7 +564,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1ff57988-8533-4b75-b8ae-50225751b7e8",
      "showTitle": false,
@@ -526,7 +583,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8f01f521-f9fd-4e83-9912-9d4bdd72678d",
      "showTitle": false,
@@ -544,7 +604,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "2a7b1b81-3652-4dec-994b-d5b685ed1673",
      "showTitle": false,
@@ -583,7 +646,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "e06b7445-f3d8-4761-9bfc-0a990a0cebad",
      "showTitle": false,
@@ -624,7 +690,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1bae2696-e5c6-4bda-adb3-c99f5345da0d",
      "showTitle": false,
@@ -663,7 +732,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "df03e226-33b2-450c-a8db-d59a4854c0e9",
      "showTitle": false,
@@ -700,7 +772,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "82ccdca6-69ad-4453-b91b-5231abe20c7f",
      "showTitle": false,
@@ -740,7 +815,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "5b383891-d6d2-4445-930e-350ae7d17e95",
      "showTitle": false,
@@ -777,7 +855,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ff523cc2-7791-40c9-9418-ceed09dedce1",
      "showTitle": false,
@@ -816,7 +897,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ae5d493f-e852-4924-85c7-dd39a0130092",
      "showTitle": false,
@@ -856,7 +940,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "3e0c1093-ce6e-4094-a7c4-8fe878c401b6",
      "showTitle": false,
@@ -872,7 +959,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "7528c106-c83b-4d8e-8b32-78e820647d93",
      "showTitle": false,
@@ -913,7 +1003,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "51b5e7be-7c74-439f-89ae-5f20e341b82a",
      "showTitle": false,
@@ -957,7 +1050,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "db9f3706-7536-46e6-a09a-3d972f21bc4a",
      "showTitle": false,
@@ -968,7 +1064,10 @@
    "source": [
     "#### Removing widgets\n",
     "\n",
-    "If you need to remove a widget, you can do so using the following syntax within a SQL code chunk:"
+    "If you need to remove a widget, you can do so using the following syntax within a SQL code chunk:\n",
+    "\n",
+    "**IMPORTANT NOTE:** If your cluster is running Databricks Runtime (DBR) 17.2 or 17.3 LTS the SQL syntax for removing widgets is broken due to a bug in the Databricks runtime code. \n",
+    "As a result the below 2 cells will not work and will throw a `TypeError`. To work around this issue uncomment the code in the cell titled `DBR 17 Fix` below using `Ctrl + K + U` and run that instead of the cells 47 & 48. This bug isn't present in DBR 16.x, DBR 17.1, or DBR 18.1. "
    ]
   },
   {
@@ -1022,6 +1121,47 @@
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
      "inputWidgets": {},
+     "nuid": "16df8c1a-78d5-46aa-a236-e4db783651d0",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "##### DBR 17.2 / DBR 17.3 LTS workaround\n",
+    "\n",
+    "As mention above the SQL Syntax for removing widgets was broken in DBR 17.2/17.3 LTS. As such we'll need to use an `R` or `python` command to do the same thing. If your cluster uses these versions you can remove the widgets created above by uncommenting the code chunk below and running it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "a8d74913-9a59-4ca6-af8a-1799c1c0247e",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "DBR 17 Fix"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "-- %r\n",
+    "\n",
+    "-- dbutils.widgets.removeAll()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
      "nuid": "5a37ab06-80c3-4c2b-b5d1-d4f7e01716bd",
      "showTitle": false,
      "tableResultSettingsMap": {},
@@ -1044,7 +1184,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "0fb27057-0171-4625-b1cc-1d7c94f621d7",
      "showTitle": false,
@@ -1084,7 +1227,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a97fadce-f6e5-4f88-939b-7f52b0adf011",
      "showTitle": false,
@@ -1123,7 +1269,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "3191c359-4c8a-4fdf-9aa1-2ef9649b992c",
      "showTitle": false,
@@ -1186,7 +1335,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "4ff12579-6d97-4ea0-bc31-e77a6099daf5",
      "showTitle": false,
@@ -1247,7 +1399,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "483da57c-f98d-4bfe-a4f5-32943a523176",
      "showTitle": false,
@@ -1307,7 +1462,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "05166eea-19eb-474b-8171-837ff6101837",
      "showTitle": false,
@@ -1350,7 +1508,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "558d7498-7862-40cb-b2a8-ac9b899b0951",
      "showTitle": false,
@@ -1393,7 +1554,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "fe32f6b9-3a9b-496a-9c73-afc858ab0872",
      "showTitle": false,
@@ -1434,7 +1598,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "50e92284-4506-4775-9faf-1b29652bf8a9",
      "showTitle": false,
@@ -1474,7 +1641,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "4dd5946b-bdec-4407-a957-93225bda7dbe",
      "showTitle": false,
@@ -1520,7 +1690,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a99b3ddf-7873-4ca9-9d33-f3f8af74a296",
      "showTitle": false,
@@ -1561,7 +1734,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "7bd20262-f62c-46eb-b7df-60a5ef6a2cd1",
      "showTitle": false,
@@ -1608,7 +1784,182 @@
     "pythonIndentUnit": 4
    },
    "notebookName": "01 - Notebooks and chunks",
-   "widgets": {}
+   "widgets": {
+    "sql_combo": {
+     "currentValue": "Aadvark",
+     "nuid": "30c0314f-ea5a-4c3b-a337-b12e80869bea",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "Aadvark",
+      "label": null,
+      "name": "sql_combo",
+      "options": {
+       "widgetDisplayType": "Dropdown",
+       "choices": [
+        "Aadvark",
+        "Arrow",
+        "Apple",
+        "Banana"
+       ],
+       "fixedDomain": false,
+       "multiselect": false
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "combobox",
+      "defaultValue": "Aadvark",
+      "label": null,
+      "name": "sql_combo",
+      "options": {
+       "widgetType": "dropdown",
+       "autoCreated": false,
+       "choices": [
+        "Aadvark",
+        "Arrow",
+        "Apple",
+        "Banana"
+       ]
+      }
+     }
+    },
+    "sql_dropdown": {
+     "currentValue": "A",
+     "nuid": "886498e0-7c12-4767-991f-f0bf15ad845b",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "A",
+      "label": null,
+      "name": "sql_dropdown",
+      "options": {
+       "widgetDisplayType": "Dropdown",
+       "choices": [
+        "A",
+        "B",
+        "C"
+       ],
+       "fixedDomain": true,
+       "multiselect": false
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "dropdown",
+      "defaultValue": "A",
+      "label": null,
+      "name": "sql_dropdown",
+      "options": {
+       "widgetType": "dropdown",
+       "autoCreated": false,
+       "choices": [
+        "A",
+        "B",
+        "C"
+       ]
+      }
+     }
+    },
+    "sql_multi": {
+     "currentValue": "Aadvark",
+     "nuid": "5c0c5435-ecc3-4afc-9322-263600bfdcde",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "Aadvark",
+      "label": null,
+      "name": "sql_multi",
+      "options": {
+       "widgetDisplayType": "Dropdown",
+       "choices": [
+        "Aadvark",
+        "Arrow",
+        "Apple",
+        "Banana"
+       ],
+       "fixedDomain": true,
+       "multiselect": true
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "multiselect",
+      "defaultValue": "Aadvark",
+      "label": null,
+      "name": "sql_multi",
+      "options": {
+       "widgetType": "dropdown",
+       "autoCreated": false,
+       "choices": [
+        "Aadvark",
+        "Arrow",
+        "Apple",
+        "Banana"
+       ]
+      }
+     }
+    },
+    "sql_table_name": {
+     "currentValue": "steam_game_reviews",
+     "nuid": "43541fe8-1481-41ab-a30d-4a676f9bca08",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "steam_game_reviews",
+      "label": null,
+      "name": "sql_table_name",
+      "options": {
+       "widgetDisplayType": "Dropdown",
+       "choices": [
+        "steam_game_reviews",
+        "games_description",
+        "games_ranking"
+       ],
+       "fixedDomain": true,
+       "multiselect": false
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "dropdown",
+      "defaultValue": "steam_game_reviews",
+      "label": null,
+      "name": "sql_table_name",
+      "options": {
+       "widgetType": "dropdown",
+       "autoCreated": false,
+       "choices": [
+        "steam_game_reviews",
+        "games_description",
+        "games_ranking"
+       ]
+      }
+     }
+    },
+    "sql_text": {
+     "currentValue": "This is a SQL text widget",
+     "nuid": "2d49fc19-0ad9-4588-a6db-c183ca4999de",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "This is a SQL text widget",
+      "label": null,
+      "name": "sql_text",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "This is a SQL text widget",
+      "label": null,
+      "name": "sql_text",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    }
+   }
   },
   "language_info": {
    "name": "sql"


### PR DESCRIPTION
…17.2/3 LTS

## Overview of changes

When using DBR 17.2 or 17.3 LTS the `REMOVE WIDGET` SQL syntax fails due to a bug in the DBR code. This pull request explains why and offers a workaround for users who are using a cluster with that DBR.

## Why are these changes being made?

Analysts are being directed to use this repo as a training material and an unexplained error is confusing and frustrating for them to experience. There is nothing we can do to fix the issue as it is a result of the Databrick run time code but this pull request explains the issue and offers a workaround.

## Checklist
- [x] I have updated the documentation


## Reviewer instructions

Read through the notebook `01 - Notebooks and chunks` section on Widgets (specifically SQL).