### PR TITLE
Removed section on broken DBR as this has now been fixed.

### DIFF
--- a/02 - Notebooks/01 - Notebooks and chunks.ipynb
+++ b/02 - Notebooks/01 - Notebooks and chunks.ipynb
@@ -842,7 +842,14 @@
      "inputWidgets": {},
      "nuid": "af190af6-63e7-4e2f-a05e-e0ae91eab399",
      "showTitle": false,
-     "tableResultSettingsMap": {},
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1772026730343}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
      "title": ""
     }
    },
@@ -927,7 +934,14 @@
      "inputWidgets": {},
      "nuid": "b9261996-8cc6-4487-843b-2034d441734d",
      "showTitle": false,
-     "tableResultSettingsMap": {},
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1772026731336}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
      "title": ""
     }
    },
@@ -1113,44 +1127,6 @@
     "REMOVE WIDGET sql_multi;\n",
     "REMOVE WIDGET sql_text;\n",
     "REMOVE WIDGET sql_table_name;"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "16df8c1a-78d5-46aa-a236-e4db783651d0",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "source": [
-    "##### DBR 17.2 / DBR 17.3 LTS workaround\n",
-    "\n",
-    "As mention above the SQL Syntax for removing widgets was broken in DBR 17.2/17.3 LTS. As such we'll need to use an `R` or `python` command to do the same thing. If your cluster uses these versions you can remove the widgets created above by uncommenting the code chunk below and running it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "a8d74913-9a59-4ca6-af8a-1799c1c0247e",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "DBR 17 Fix"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "-- %r\n",
-    "\n",
-    "-- dbutils.widgets.removeAll()"
    ]
   },
   {
@@ -1670,7 +1646,14 @@
      "inputWidgets": {},
      "nuid": "dbbaa04a-b5e9-4195-8b37-206abeff5afe",
      "showTitle": false,
-     "tableResultSettingsMap": {},
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1772027026433}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
      "title": ""
     }
    },
@@ -1786,159 +1769,89 @@
    "notebookName": "01 - Notebooks and chunks",
    "widgets": {
     "sql_combo": {
-     "currentValue": "Aadvark",
-     "nuid": "30c0314f-ea5a-4c3b-a337-b12e80869bea",
+     "currentValue": "",
+     "nuid": "d43ade15-3010-43f2-9e4c-7fc415a56700",
      "typedWidgetInfo": {
-      "autoCreated": false,
-      "defaultValue": "Aadvark",
+      "autoCreated": true,
+      "defaultValue": "",
       "label": null,
       "name": "sql_combo",
       "options": {
-       "widgetDisplayType": "Dropdown",
-       "choices": [
-        "Aadvark",
-        "Arrow",
-        "Apple",
-        "Banana"
-       ],
-       "fixedDomain": false,
-       "multiselect": false
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "combobox",
-      "defaultValue": "Aadvark",
+      "widgetType": "text",
+      "defaultValue": "",
       "label": null,
       "name": "sql_combo",
       "options": {
-       "widgetType": "dropdown",
-       "autoCreated": false,
-       "choices": [
-        "Aadvark",
-        "Arrow",
-        "Apple",
-        "Banana"
-       ]
+       "widgetType": "text",
+       "autoCreated": true,
+       "validationRegex": null
       }
      }
     },
     "sql_dropdown": {
-     "currentValue": "A",
-     "nuid": "886498e0-7c12-4767-991f-f0bf15ad845b",
+     "currentValue": "",
+     "nuid": "9e2d1dff-b591-4e65-9d5d-cb1ff24f1d34",
      "typedWidgetInfo": {
-      "autoCreated": false,
-      "defaultValue": "A",
+      "autoCreated": true,
+      "defaultValue": "",
       "label": null,
       "name": "sql_dropdown",
       "options": {
-       "widgetDisplayType": "Dropdown",
-       "choices": [
-        "A",
-        "B",
-        "C"
-       ],
-       "fixedDomain": true,
-       "multiselect": false
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "dropdown",
-      "defaultValue": "A",
+      "widgetType": "text",
+      "defaultValue": "",
       "label": null,
       "name": "sql_dropdown",
       "options": {
-       "widgetType": "dropdown",
-       "autoCreated": false,
-       "choices": [
-        "A",
-        "B",
-        "C"
-       ]
+       "widgetType": "text",
+       "autoCreated": true,
+       "validationRegex": null
       }
      }
     },
     "sql_multi": {
-     "currentValue": "Aadvark",
-     "nuid": "5c0c5435-ecc3-4afc-9322-263600bfdcde",
+     "currentValue": "",
+     "nuid": "a78e014f-a58c-4069-9a30-50a24e04a236",
      "typedWidgetInfo": {
-      "autoCreated": false,
-      "defaultValue": "Aadvark",
+      "autoCreated": true,
+      "defaultValue": "",
       "label": null,
       "name": "sql_multi",
       "options": {
-       "widgetDisplayType": "Dropdown",
-       "choices": [
-        "Aadvark",
-        "Arrow",
-        "Apple",
-        "Banana"
-       ],
-       "fixedDomain": true,
-       "multiselect": true
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "multiselect",
-      "defaultValue": "Aadvark",
+      "widgetType": "text",
+      "defaultValue": "",
       "label": null,
       "name": "sql_multi",
       "options": {
-       "widgetType": "dropdown",
-       "autoCreated": false,
-       "choices": [
-        "Aadvark",
-        "Arrow",
-        "Apple",
-        "Banana"
-       ]
-      }
-     }
-    },
-    "sql_table_name": {
-     "currentValue": "steam_game_reviews",
-     "nuid": "43541fe8-1481-41ab-a30d-4a676f9bca08",
-     "typedWidgetInfo": {
-      "autoCreated": false,
-      "defaultValue": "steam_game_reviews",
-      "label": null,
-      "name": "sql_table_name",
-      "options": {
-       "widgetDisplayType": "Dropdown",
-       "choices": [
-        "steam_game_reviews",
-        "games_description",
-        "games_ranking"
-       ],
-       "fixedDomain": true,
-       "multiselect": false
-      },
-      "parameterDataType": "String"
-     },
-     "widgetInfo": {
-      "widgetType": "dropdown",
-      "defaultValue": "steam_game_reviews",
-      "label": null,
-      "name": "sql_table_name",
-      "options": {
-       "widgetType": "dropdown",
-       "autoCreated": false,
-       "choices": [
-        "steam_game_reviews",
-        "games_description",
-        "games_ranking"
-       ]
+       "widgetType": "text",
+       "autoCreated": true,
+       "validationRegex": null
       }
      }
     },
     "sql_text": {
-     "currentValue": "This is a SQL text widget",
-     "nuid": "2d49fc19-0ad9-4588-a6db-c183ca4999de",
+     "currentValue": "",
+     "nuid": "f25f417a-bc6b-4fe3-8d16-7f3dcf4f78b5",
      "typedWidgetInfo": {
-      "autoCreated": false,
-      "defaultValue": "This is a SQL text widget",
+      "autoCreated": true,
+      "defaultValue": "",
       "label": null,
       "name": "sql_text",
       "options": {
@@ -1949,12 +1862,12 @@
      },
      "widgetInfo": {
       "widgetType": "text",
-      "defaultValue": "This is a SQL text widget",
+      "defaultValue": "",
       "label": null,
       "name": "sql_text",
       "options": {
        "widgetType": "text",
-       "autoCreated": false,
+       "autoCreated": true,
        "validationRegex": null
       }
      }


### PR DESCRIPTION
## Overview of changes

Removed the section in `02 - Notebooks\01 - Notebooks and chunks` on how to work around the issue where DBR 17.x would throw an error when using SQL syntax to remove a widget.

This is now fixed in DBR 17.x so is no longer required, and risks confusing people as they work through.

## Why are these changes being made?

Databricks have implemented a fix for the Databricks Runtimes affected, and the work around is no longer required.

## Checklist

- [x] I have updated the documentation


## Reviewer instructions

Check that you can run all chunks within `02 - Notebooks\01 - Notebooks and chunks` without any errors.