### PR TITLE
Set catalog and schema in `04 - Importing Data using sparklyr`

### DIFF
--- a/02 - Notebooks/04 - Importing Data using sparklyr.ipynb
+++ b/02 - Notebooks/04 - Importing Data using sparklyr.ipynb
@@ -4,7 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "69f8b1d0-d3fd-4be5-b008-bba09de02d2c",
      "showTitle": false,
@@ -26,7 +29,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "89ebc4e0-0e03-40dc-b4ad-a09c4613b2f0",
      "showTitle": false,
@@ -71,7 +77,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "c37d7671-4116-405e-b154-ce8167fcdbc2",
      "showTitle": false,
@@ -133,7 +142,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "80733d99-61ee-4e3c-a059-2d0ff2eb84f3",
      "showTitle": false,
@@ -152,7 +164,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a8e2c7ba-dd86-43bc-bdec-247e639578c4",
      "showTitle": false,
@@ -170,7 +185,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "67837cbb-9d4c-4bef-b5c1-e01c4a7a219d",
      "showTitle": false,
@@ -216,7 +234,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "86bcbd8b-e2da-4961-9b5c-4454983feb5e",
      "showTitle": false,
@@ -233,7 +254,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "44cddb33-6bd0-4965-a025-890a935f166c",
      "showTitle": false,
@@ -251,7 +275,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "c19552de-8263-4042-9ae9-a3414ef43312",
      "showTitle": false,
@@ -276,7 +303,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "fdefe5fa-5679-421e-afcb-88be0fc4a4ef",
      "showTitle": false,
@@ -294,7 +324,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ce362beb-0304-45b9-86ae-7c391ab44e15",
      "showTitle": false,
@@ -311,7 +344,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "018b5f1c-6432-4677-9786-fa0c94f800fb",
      "showTitle": false,
@@ -329,7 +365,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ce2063b3-7631-4de8-af6c-872664ec1f25",
      "showTitle": false,
@@ -346,7 +385,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "c5a8ca2e-43f8-4a73-8eab-34e1a4adbc0d",
      "showTitle": false,
@@ -365,7 +407,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "cd298445-2394-4f11-a93b-7b8dac30afec",
      "showTitle": false,
@@ -382,7 +427,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "9be20346-28a4-40ec-8550-4e58c5f176dc",
      "showTitle": false,
@@ -400,7 +448,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ce9ad8bc-a372-4315-a60b-af95ea0196f4",
      "showTitle": false,
@@ -422,7 +473,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "0e3fcc2f-6550-4492-9b7e-e71bbc8cf890",
      "showTitle": false,
@@ -442,7 +496,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "65390e2e-e823-4f3a-9173-87e262464882",
      "showTitle": false,
@@ -459,7 +516,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a59788f9-48f0-4e3b-bd4c-98e43b96c085",
      "showTitle": false,
@@ -481,7 +541,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "b70d7121-779f-4e38-839d-0249b639658d",
      "showTitle": false,
@@ -498,7 +561,10 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "d17f49ab-21d1-4b38-8e41-54ebbeaf3d93",
      "showTitle": false,
@@ -515,7 +581,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "b9555437-b6d2-4a36-bb00-e3451dc21072",
      "showTitle": false,
@@ -542,7 +611,7 @@
    "notebookName": "04 - Importing Data using sparklyr",
    "widgets": {
     "catalog": {
-     "currentValue": "catalog_40_copper_ma_fedu_s_data",
+     "currentValue": "catalog_40_copper_longitudinal_ilr",
      "nuid": "7351142d-ea73-4fc5-94ed-6d77e6faef28",
      "typedWidgetInfo": {
       "autoCreated": false,
@@ -563,13 +632,13 @@
       "name": "catalog",
       "options": {
        "widgetType": "text",
-       "autoCreated": false,
+       "autoCreated": null,
        "validationRegex": null
       }
      }
     },
     "schema": {
-     "currentValue": "test",
+     "currentValue": "lilr_dev_test",
      "nuid": "6720e4eb-59ed-47c0-b63b-fb2cd9fd94fc",
      "typedWidgetInfo": {
       "autoCreated": false,
@@ -590,7 +659,7 @@
       "name": "schema",
       "options": {
        "widgetType": "text",
-       "autoCreated": false,
+       "autoCreated": null,
        "validationRegex": null
       }
      }

--- a/02 - Notebooks/04 - Importing Data using sparklyr.ipynb
+++ b/02 - Notebooks/04 - Importing Data using sparklyr.ipynb
@@ -218,6 +218,41 @@
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
      "inputWidgets": {},
+     "nuid": "86bcbd8b-e2da-4961-9b5c-4454983feb5e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "Now that we've connected to the database we can tell the connection what data catalog and schema to use for our later commands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "44cddb33-6bd0-4965-a025-890a935f166c",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sdf_sql(sc, paste0(\"USE CATALOG \", catalog))\n",
+    "sdf_sql(sc, paste0(\"USE SCHEMA \", schema))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
      "nuid": "c19552de-8263-4042-9ae9-a3414ef43312",
      "showTitle": false,
      "tableResultSettingsMap": {},
@@ -518,7 +553,8 @@
        "widgetDisplayType": "Text",
        "validationRegex": null
       },
-      "parameterDataType": "String"
+      "parameterDataType": "String",
+      "dynamic": false
      },
      "widgetInfo": {
       "widgetType": "text",
@@ -544,7 +580,8 @@
        "widgetDisplayType": "Text",
        "validationRegex": null
       },
-      "parameterDataType": "String"
+      "parameterDataType": "String",
+      "dynamic": false
      },
      "widgetInfo": {
       "widgetType": "text",


### PR DESCRIPTION
## Overview of changes

Corrects an error in `04 - Importing Data using sparklyr` where the catalog and schema are not set globally for the notebook, causing the `spark_write_table()` command in cell 23 (as-was, now cell 25) to fail.

Prior to fix:
<img width="1074" height="328" alt="image" src="https://github.com/user-attachments/assets/06492091-d17b-4056-a5f3-dc7c6bbca5f7" />

After fix:
<img width="1512" height="755" alt="image" src="https://github.com/user-attachments/assets/57d6f573-34c2-464f-a614-7c73d09fb85f" />


## Why are these changes being made?

Notebook intention was to set the catalog and schema globally before write (as evidenced by the creation of widgets and variables for it. 

Think this previously did work and a cell may have been removed, so this fix restores the intended functionality.

## Checklist

- [x] I have tested these changes in my own environment
- [x] I have updated the documentation


## Reviewer instructions

Run through notebook `04 - Importing Data using sparklyr` following the instructions and verify that it now runs without error.
